### PR TITLE
Turn based movement

### DIFF
--- a/Actors/Monster.py
+++ b/Actors/Monster.py
@@ -11,6 +11,8 @@ class Monster(Actor):
     def move(self, player, dungeon_map):
         next_move = self.ai.next_move(self, player)
         self.facing = self.determine_direction(next_move.row, next_move.col)
+
+        #Checking for collisions with other monsters
         if dungeon_map.grid[next_move.row][next_move.col] == FLOOR:
             self.row = next_move.row
             self.col = next_move.col

--- a/Actors/Monster.py
+++ b/Actors/Monster.py
@@ -8,11 +8,12 @@ class Monster(Actor):
         self.ai = MonsterAI(dungeon_map)
 
     # overwritten to use the AI to determine the move to make
-    def move(self, player):
+    def move(self, player, dungeon_map):
         next_move = self.ai.next_move(self, player)
         self.facing = self.determine_direction(next_move.row, next_move.col)
-        self.row = next_move.row
-        self.col = next_move.col
+        if dungeon_map.grid[next_move.row][next_move.col] == FLOOR:
+            self.row = next_move.row
+            self.col = next_move.col
 
 class SkullMonster(Monster):
     def __init__(self, row, col, dungeon_map):

--- a/Behaviors/MonsterAI.py
+++ b/Behaviors/MonsterAI.py
@@ -1,6 +1,7 @@
 from definitions import *
 from queue import Queue #for BFS
 import random # for shuffling the directional array
+import copy
 
 # Basically a struct to hold a row and column to make the BFS easier
 class Position:
@@ -23,7 +24,7 @@ class Position:
 
 class MonsterAI:
     def __init__(self, dungeon_map):
-        self.dungeon_map = dungeon_map
+        self.dungeon_map = copy.deepcopy(dungeon_map)
 
 
     def solve(self, monster, player): #BFS. Pulled from my C++ code from PPW homework 1

--- a/Maps/DungeonMap.py
+++ b/Maps/DungeonMap.py
@@ -17,14 +17,14 @@ class DungeonMap():
             for col in range(1, COLUMN_COUNT-1):
                 self.grid[row][col] = FLOOR
 
-    def update_dungeon(self, actors):
+    def update_dungeon(self, old_actors, new_actors):
         # remove previous positions of actors
-        for row in range(ROW_COUNT):
-            for col in range(COLUMN_COUNT):
-                if self.grid[row][col] == ACTOR:
-                    self.grid[row][col] = FLOOR
+        if old_actors != []: #if we aren't just initializing the list for the first time
+            for actor in old_actors:
+                # print("making spot into a floor", actor.row, actor.col)
+                self.grid[actor.row][actor.col] = FLOOR
         # update the grid to track the positions of the actors
-        for actor in actors:
+        for actor in new_actors:
             self.grid[actor.row][actor.col] = ACTOR
 
 

--- a/Maps/DungeonMap.py
+++ b/Maps/DungeonMap.py
@@ -21,7 +21,6 @@ class DungeonMap():
         # remove previous positions of actors
         if old_actors != []: #if we aren't just initializing the list for the first time
             for actor in old_actors:
-                # print("making spot into a floor", actor.row, actor.col)
                 self.grid[actor.row][actor.col] = FLOOR
         # update the grid to track the positions of the actors
         for actor in new_actors:

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -46,8 +46,8 @@ class MyGame(arcade.Window):
 
         self.is_players_turn = None
 
-        # self.key_pressed = None
-        # self.key_modifiers = None
+        self.key_pressed = None
+        self.key_modifiers = None
 
         # Used to make the monsters move after a slight delay and 1 by 1 instead
         # of them all swarming the player at once
@@ -96,21 +96,29 @@ class MyGame(arcade.Window):
         Normally, you'll call update() on the sprite lists that
         need it.
         """
+        # self.map.update_dungeon(self.actors_list)
+
+        if self.is_players_turn and self.key_pressed != None:
+            self.player_turn(self.key_pressed, self.key_modifiers)
+            self.key_pressed = None
+
+        self.map.update_dungeon(self.actors_list)
 
         if not self.is_players_turn:
             self.monster_move_timer += 1
 
             if self.monster_move_timer > 20:
+                # self.map.update_dungeon(self.actors_list)
                 if self.monster_turn < len(self.monsters_list):
                     self.monsters_list[self.monster_turn].move(self.player)
                     self.monster_turn += 1
+                    self.monster_move_timer = 0
                 else:
-                    self.is_players_turn = True
                     self.monster_turn = 0
+                    self.is_players_turn = True
             else:
                 return;
 
-        self.map.update_dungeon(self.actors_list)
 
 
 
@@ -118,13 +126,20 @@ class MyGame(arcade.Window):
         """Called whenever a key is pressed. """
         if self.is_players_turn:
             if key == arcade.key.UP:
-                self.player_turn(UP, modifiers)
+                self.key_pressed = UP
+                self.key_modifiers = modifiers
             elif key == arcade.key.DOWN:
-                self.player_turn(DOWN, modifiers)
+                self.key_pressed = DOWN
+                self.key_modifiers = modifiers
             elif key == arcade.key.LEFT:
-                self.player_turn(LEFT, modifiers)
+                self.key_pressed = LEFT
+                self.key_modifiers = modifiers
             elif key == arcade.key.RIGHT:
-                self.player_turn(RIGHT, modifiers)
+                self.key_pressed = RIGHT
+                self.key_modifiers = modifiers
+            else:
+                self.key_pressed = None
+                self.key_modifiers = None
 
     # moves and/or changes the direction of the player based on the key pressed
     def player_turn(self, direction, key_modifiers):

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -45,11 +45,14 @@ class MyGame(arcade.Window):
         self.actors_list = None
 
         self.is_players_turn = None
-        # self.frame_count = None
 
         # self.key_pressed = None
         # self.key_modifiers = None
+
+        # Used to make the monsters move after a slight delay and 1 by 1 instead
+        # of them all swarming the player at once
         self.monster_move_timer = None
+        self.monster_turn = None
 
 
     def setup(self):
@@ -59,7 +62,7 @@ class MyGame(arcade.Window):
 
         self.monsters_list = []
         self.monsters_list.append(LampMonster(4, 4, self.map))
-        # self.monsters_list.append(SkullMonster(5, 6, self.map))
+        self.monsters_list.append(SkullMonster(5, 6, self.map))
 
         self.actors_list = []
         self.actors_list.append(self.player)
@@ -68,9 +71,9 @@ class MyGame(arcade.Window):
         self.map.update_dungeon(self.actors_list)
 
         self.is_players_turn = True
-        # Used to make the monsters move after a slight delay and 1 by 1 instead
-        # of them all swarming the player at once
+
         self.monster_move_timer = 0
+        self.monster_turn = 0
 
     def on_draw(self):
         """
@@ -84,7 +87,8 @@ class MyGame(arcade.Window):
         # Call draw() on all your sprite lists below
         self.map.draw()
         self.player.draw()
-        self.monsters_list[0].draw()
+        for monster in self.monsters_list:
+            monster.draw()
 
     def on_update(self, delta_time):
         """
@@ -95,9 +99,14 @@ class MyGame(arcade.Window):
 
         if not self.is_players_turn:
             self.monster_move_timer += 1
-            if self.monster_move_timer > 20: #
-                self.monsters_list[0].move(self.player)
-                self.is_players_turn = True
+
+            if self.monster_move_timer > 20:
+                if self.monster_turn < len(self.monsters_list):
+                    self.monsters_list[self.monster_turn].move(self.player)
+                    self.monster_turn += 1
+                else:
+                    self.is_players_turn = True
+                    self.monster_turn = 0
             else:
                 return;
 

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -98,7 +98,6 @@ class MyGame(arcade.Window):
         need it.
         """
         old_actors = copy.deepcopy(self.actors_list)
-        # self.map.update_dungeon(self.actors_list)
 
         if self.is_players_turn and self.key_pressed != None:
             self.player_turn(self.key_pressed, self.key_modifiers)
@@ -107,16 +106,15 @@ class MyGame(arcade.Window):
             # print("new",self.actors_list[0].row, self.actors_list[0].col)
 
         self.map.update_dungeon(old_actors, self.actors_list)
-        old_actors = self.actors_list
-
+        old_actors = copy.deepcopy(self.actors_list)
 
         if not self.is_players_turn:
             self.monster_move_timer += 1
 
-            if self.monster_move_timer > 20:
-                # self.map.update_dungeon(self.actors_list)
+            if self.monster_move_timer > 7:
                 if self.monster_turn < len(self.monsters_list):
-                    self.monsters_list[self.monster_turn].move(self.player)
+                    self.monsters_list[self.monster_turn].move(self.player, self.map)
+                    self.map.update_dungeon(old_actors, self.actors_list)
                     self.monster_turn += 1
                     self.monster_move_timer = 0
                 else:

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -17,7 +17,9 @@ from Maps.DungeonMap import DungeonMap
 from Actors.Player import Player
 from Actors.Monster import *
 
-# detects if the direction the player is trying to move to is valid
+"""
+Detects if the direction the player is trying to move to is valid
+"""
 def player_collision(player, direction, map):
     return(map.get_tile_type(player.row+direction[0], player.col+direction[1]) != FLOOR)
 
@@ -33,6 +35,10 @@ class MyGame(arcade.Window):
     """
 
     def __init__(self, width, height, title):
+        """
+        Initializes things like the window size and background color
+        and declares all class variables
+        """
         super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.AMAZON)
@@ -43,10 +49,12 @@ class MyGame(arcade.Window):
 
         self.player = None
         self.monsters_list = None
+        # Used to track the positions of all actors for collision detection.
         self.actors_list = None
 
         self.is_players_turn = None
 
+        # Used to make the player momve during the update step, which is best practice
         self.key_pressed = None
         self.key_modifiers = None
 
@@ -57,7 +65,9 @@ class MyGame(arcade.Window):
 
 
     def setup(self):
-        # initializes all class attributes
+        """
+        Initializes all class attributes
+        """
         self.map = DungeonMap()
         self.player = Player()
 
@@ -102,8 +112,6 @@ class MyGame(arcade.Window):
         if self.is_players_turn and self.key_pressed != None:
             self.player_turn(self.key_pressed, self.key_modifiers)
             self.key_pressed = None
-            # print("old",old_actors[0].row, old_actors[0].col)
-            # print("new",self.actors_list[0].row, self.actors_list[0].col)
 
         self.map.update_dungeon(old_actors, self.actors_list)
         old_actors = copy.deepcopy(self.actors_list)
@@ -146,10 +154,9 @@ class MyGame(arcade.Window):
     def player_turn(self, direction, key_modifiers):
         # we should always change the direction if the player hit an arrow key
         self.player.change_facing(direction)
-        '''
-        if the player hit shift+arrow, they should change directions but not move
-        and the player's turn shouldn't end
-        '''
+
+        # if the player hit shift+arrow, they should change directions but not move
+        # and the player's turn shouldn't end
         if(not player_collision(self.player, direction, self.map) and key_modifiers != arcade.key.MOD_SHIFT):
             self.player.move(direction)
             self.is_players_turn = False

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -111,7 +111,7 @@ class MyGame(arcade.Window):
         if not self.is_players_turn:
             self.monster_move_timer += 1
 
-            if self.monster_move_timer > 7:
+            if self.monster_move_timer > 5:
                 if self.monster_turn < len(self.monsters_list):
                     self.monsters_list[self.monster_turn].move(self.player, self.map)
                     self.map.update_dungeon(old_actors, self.actors_list)
@@ -123,23 +123,19 @@ class MyGame(arcade.Window):
             else:
                 return;
 
-        self.map.update_dungeon(old_actors, self.actors_list)
-
-
-
     def on_key_press(self, key, modifiers):
         """Called whenever a key is pressed. """
         if self.is_players_turn:
-            if key == arcade.key.UP:
+            if key == arcade.key.UP or key == arcade.key.W:
                 self.key_pressed = UP
                 self.key_modifiers = modifiers
-            elif key == arcade.key.DOWN:
+            elif key == arcade.key.DOWN or key == arcade.key.S:
                 self.key_pressed = DOWN
                 self.key_modifiers = modifiers
-            elif key == arcade.key.LEFT:
+            elif key == arcade.key.LEFT or key == arcade.key.A:
                 self.key_pressed = LEFT
                 self.key_modifiers = modifiers
-            elif key == arcade.key.RIGHT:
+            elif key == arcade.key.RIGHT or key == arcade.key.D:
                 self.key_pressed = RIGHT
                 self.key_modifiers = modifiers
             else:

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -9,6 +9,7 @@ python -m arcade.examples.starting_template
 """
 
 import time
+import copy
 
 from definitions import *
 
@@ -68,7 +69,7 @@ class MyGame(arcade.Window):
         self.actors_list.append(self.player)
         self.actors_list.extend(self.monsters_list)
 
-        self.map.update_dungeon(self.actors_list)
+        self.map.update_dungeon([], self.actors_list)
 
         self.is_players_turn = True
 
@@ -96,13 +97,18 @@ class MyGame(arcade.Window):
         Normally, you'll call update() on the sprite lists that
         need it.
         """
+        old_actors = copy.deepcopy(self.actors_list)
         # self.map.update_dungeon(self.actors_list)
 
         if self.is_players_turn and self.key_pressed != None:
             self.player_turn(self.key_pressed, self.key_modifiers)
             self.key_pressed = None
+            # print("old",old_actors[0].row, old_actors[0].col)
+            # print("new",self.actors_list[0].row, self.actors_list[0].col)
 
-        self.map.update_dungeon(self.actors_list)
+        self.map.update_dungeon(old_actors, self.actors_list)
+        old_actors = self.actors_list
+
 
         if not self.is_players_turn:
             self.monster_move_timer += 1
@@ -119,6 +125,7 @@ class MyGame(arcade.Window):
             else:
                 return;
 
+        self.map.update_dungeon(old_actors, self.actors_list)
 
 
 

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -42,6 +42,8 @@ class MyGame(arcade.Window):
         self.monsters_list = None
         self.actors_list = None
 
+        self.is_players_turn = None
+
     def setup(self):
         # initializes all class attributes
         self.map = DungeonMap()
@@ -55,6 +57,8 @@ class MyGame(arcade.Window):
         self.actors_list.extend(self.monsters_list)
 
         self.map.update_dungeon(self.actors_list)
+
+        self.is_players_turn = True
 
     def on_draw(self):
         """
@@ -76,10 +80,26 @@ class MyGame(arcade.Window):
         Normally, you'll call update() on the sprite lists that
         need it.
         """
-        # self.actors_list = []
-        # self.actors_list.append(self.player)
-        # self.actors_list.extend(self.monsters_list)
+        if not self.is_players_turn:
+            print("Player is at ", self.player.row, self.player.col)
+            self.monsters_list[0].move(self.player)
+            self.is_players_turn = True
+
         self.map.update_dungeon(self.actors_list)
+
+
+
+    def on_key_press(self, key, modifiers):
+        """Called whenever a key is pressed. """
+        if self.is_players_turn:
+            if key == arcade.key.UP:
+                self.player_turn(UP, modifiers)
+            elif key == arcade.key.DOWN:
+                self.player_turn(DOWN, modifiers)
+            elif key == arcade.key.LEFT:
+                self.player_turn(LEFT, modifiers)
+            elif key == arcade.key.RIGHT:
+                self.player_turn(RIGHT, modifiers)
 
     # moves and/or changes the direction of the player based on the key pressed
     def player_turn(self, direction, key_modifiers):
@@ -91,20 +111,7 @@ class MyGame(arcade.Window):
         '''
         if(not player_collision(self.player, direction, self.map) and key_modifiers != arcade.key.MOD_SHIFT):
             self.player.move(direction)
-            self.monsters_list[0].move(self.player)
-
-    def on_key_press(self, key, modifiers):
-        """Called whenever a key is pressed. """
-
-        if key == arcade.key.UP:
-            self.player_turn(UP, modifiers)
-        elif key == arcade.key.DOWN:
-            self.player_turn(DOWN, modifiers)
-        elif key == arcade.key.LEFT:
-            self.player_turn(LEFT, modifiers)
-        elif key == arcade.key.RIGHT:
-            self.player_turn(RIGHT, modifiers)
-
+            self.is_players_turn = False
 
 
 def main():

--- a/arcade_main.py
+++ b/arcade_main.py
@@ -8,6 +8,8 @@ If Python and Arcade are installed, this example can be run from the command lin
 python -m arcade.examples.starting_template
 """
 
+import time
+
 from definitions import *
 
 from Maps.DungeonMap import DungeonMap
@@ -43,6 +45,12 @@ class MyGame(arcade.Window):
         self.actors_list = None
 
         self.is_players_turn = None
+        # self.frame_count = None
+
+        # self.key_pressed = None
+        # self.key_modifiers = None
+        self.monster_move_timer = None
+
 
     def setup(self):
         # initializes all class attributes
@@ -51,6 +59,7 @@ class MyGame(arcade.Window):
 
         self.monsters_list = []
         self.monsters_list.append(LampMonster(4, 4, self.map))
+        # self.monsters_list.append(SkullMonster(5, 6, self.map))
 
         self.actors_list = []
         self.actors_list.append(self.player)
@@ -59,6 +68,9 @@ class MyGame(arcade.Window):
         self.map.update_dungeon(self.actors_list)
 
         self.is_players_turn = True
+        # Used to make the monsters move after a slight delay and 1 by 1 instead
+        # of them all swarming the player at once
+        self.monster_move_timer = 0
 
     def on_draw(self):
         """
@@ -80,10 +92,14 @@ class MyGame(arcade.Window):
         Normally, you'll call update() on the sprite lists that
         need it.
         """
+
         if not self.is_players_turn:
-            print("Player is at ", self.player.row, self.player.col)
-            self.monsters_list[0].move(self.player)
-            self.is_players_turn = True
+            self.monster_move_timer += 1
+            if self.monster_move_timer > 20: #
+                self.monsters_list[0].move(self.player)
+                self.is_players_turn = True
+            else:
+                return;
 
         self.map.update_dungeon(self.actors_list)
 
@@ -112,6 +128,7 @@ class MyGame(arcade.Window):
         if(not player_collision(self.player, direction, self.map) and key_modifiers != arcade.key.MOD_SHIFT):
             self.player.move(direction)
             self.is_players_turn = False
+            self.monster_move_timer = 0
 
 
 def main():

--- a/definitions.py
+++ b/definitions.py
@@ -1,3 +1,11 @@
+"""
+This information is used throughout the application
+and every class needs access to arcade at a minimum
+o it's all in this file instead of me having to
+seperately import or define thes things is multiple
+places.
+"""
+
 import arcade
 
 # Set how many rows and columns we will have

--- a/tests/dungeon_map_test.py
+++ b/tests/dungeon_map_test.py
@@ -32,15 +32,15 @@ def test_update_dungeon():
     map = DungeonMap()
     player = Actor(1, 1, arcade.color.BLUE)
 
-    map.update_dungeon([player])
+    map.update_dungeon([], [player])
 
     assert(map.grid[1][1] == ACTOR) #works with a single actor
-
+    old_actors = [player]
     player2 = Actor(2, 2, arcade.color.BLUE)
-    map.update_dungeon([player, player2])
+    map.update_dungeon([player],[player, player2])
     assert(map.grid[1][1] == ACTOR) #works with a multiple actors
     assert(map.grid[2][2] == ACTOR) #works with a multiple actor
 
-    map.update_dungeon([player])
+    map.update_dungeon([player, player2], [player])
     assert(map.grid[1][1] == ACTOR) #works with a multiple actors
     assert(map.grid[2][2] != ACTOR) #resets tiles after an actor moves off of them


### PR DESCRIPTION
This PR
- Adds a turn system when the player moves, then is blocked from moving until the monsters move
- Fixes a glitch around updating the map making the monsters stop moving
- Adds a second monster
- Greatly increases the efficiency of update_dungeon, esp at bigger sizes (I think from n^2 + m to 2m)
- Fixes a glitch where a monster could move on top of a player
- Adds comments and cleans up code
